### PR TITLE
Issue 430 add weights to insure correct order of javascript loading

### DIFF
--- a/tripal_analysis_expression/tripal_analysis_expression.module
+++ b/tripal_analysis_expression/tripal_analysis_expression.module
@@ -510,13 +510,15 @@ function tripal_analysis_expression_heatmap_block(&$block)
                </a>';
 
       drupal_add_js(drupal_get_path('module',
-          'tripal_analysis_expression') . '/theme/js/plotly-latest.min.js');
+          'tripal_analysis_expression') . '/theme/js/plotly-latest.min.js',
+        ['weight' => -999]);
       drupal_add_js(['tripal_analysis_expression' => ['data' => $heatmap]],
-        ['type' => 'setting']);
+        ['type' => 'setting', 'weight' => -998]);
       drupal_add_js(['tripal_analysis_expression' => ['baseURL' => $base_url]],
-        ['type' => 'setting']);
+        ['type' => 'setting', 'weight' => -997]);
       drupal_add_js(drupal_get_path('module',
-          'tripal_analysis_expression') . '/theme/js/heatmap.js');
+          'tripal_analysis_expression') . '/theme/js/heatmap.js',
+        ['weight' => -996]);
     } else {
       $block['subject'] = '';
       if (isset($_GET['heatmap_feature_uniquename']) && !empty($_GET['heatmap_feature_uniquename'])) {


### PR DESCRIPTION
This change resolves the problem of the heatmap not appearing in issue #430.
It adds weights to make sure that javascript is loaded in the correct order.
Thanks to @laceysanderson for suggesting this.
I can't replicate the issue, https://github.com/guichenzhu has confirmed that this fix works, and local testing confirms it does not break anything.