### PR TITLE
Fix incorrect case for obi CV; add update hook

### DIFF
--- a/tripal_analysis_expression/includes/TripalFields/local__expression_details/local__expression_details.inc
+++ b/tripal_analysis_expression/includes/TripalFields/local__expression_details/local__expression_details.inc
@@ -110,7 +110,7 @@ class local__expression_details extends ChadoField{
     $feature_id = $entity->chado_record->feature_id;
 
     $pvalue_cvterm_id = chado_get_cvterm([
-      'cv_id' => ['name' => 'OBI'],
+      'cv_id' => ['name' => 'obi'],
       'name' => 'p-value',
     ])->cvterm_id;
 

--- a/tripal_analysis_expression/includes/TripalFields/local__expression_features/local__expression_features_formatter.inc
+++ b/tripal_analysis_expression/includes/TripalFields/local__expression_features/local__expression_features_formatter.inc
@@ -39,7 +39,7 @@ class local__expression_features_formatter extends ChadoFieldFormatter
   public function view(&$element, $entity_type, $entity, $langcode, $items, $display)
   {
     $pvalue_cvterm_id = chado_get_cvterm([
-      'cv_id' => ['name' => 'OBI'],
+      'cv_id' => ['name' => 'obi'],
       'name' => 'p-value',
     ])->cvterm_id;
     $evidence_code_cvterm_id = chado_get_cvterm([

--- a/tripal_analysis_expression/includes/TripalFields/local__expression_search/local__expression_search_formatter.inc
+++ b/tripal_analysis_expression/includes/TripalFields/local__expression_search/local__expression_search_formatter.inc
@@ -39,7 +39,7 @@ class local__expression_search_formatter extends ChadoFieldFormatter
   public function view(&$element, $entity_type, $entity, $langcode, $items, $display)
   {
     $pvalue_cvterm_id = chado_get_cvterm([
-      'cv_id' => ['name' => 'OBI'],
+      'cv_id' => ['name' => 'obi'],
       'name' => 'p-value',
     ])->cvterm_id;
     $evidence_code_cvterm_id = chado_get_cvterm([

--- a/tripal_analysis_expression/includes/TripalImporter/tripal_expression_pvalue_loader.inc
+++ b/tripal_analysis_expression/includes/TripalImporter/tripal_expression_pvalue_loader.inc
@@ -318,11 +318,11 @@ class tripal_expression_pvalue_loader extends TripalImporter
     $so_term = $run_args['so_term'];
 
     $this->pvalue_cvterm_id = chado_get_cvterm([
-      'cv_id' => ['name' => 'OBI'],
+      'cv_id' => ['name' => 'obi'],
       'name' => 'p-value',
     ])->cvterm_id;
     if (!$this->pvalue_cvterm_id) {
-      throw new Exception(t('The CV term "p-value" was not found in the CV "OBI". Please add this term',
+      throw new Exception(t('The CV term "p-value" was not found in the CV "obi". Please add this term',
         []));
     }
 

--- a/tripal_analysis_expression/tripal_analysis_expression.install
+++ b/tripal_analysis_expression/tripal_analysis_expression.install
@@ -240,7 +240,7 @@ function tripal_analysis_expression_add_pvalue_cvterm() {
   chado_insert_cvterm([
     'id' => 'OBI:0000175',
     'name' => 'p-value',
-    'cv_name' => 'OBI',
+    'cv_name' => 'obi',
     'db_name' => 'OBI',
     'description' => 'A quantitative confidence value that represents the probability of obtaining a result at least as extreme as that actually obtained, assuming that the actual value was the result of chance alone.'
   ]);
@@ -518,4 +518,17 @@ function tripal_analysis_expression_update_7304() {
     $error = $e->getMessage();
     throw new DrupalUpdateException('Could not perform update: ' . $error);
   }  
+}
+
+/**
+ * Corrects CV name for p-value term, formerly cv name was "OBI" but should be "obi"
+ */
+function tripal_analysis_expression_update_7305() {
+  try {
+    tripal_analysis_expression_add_pvalue_cvterm();
+  }
+  catch (\PDOException $e) {
+    $error = $e->getMessage();
+    throw new DrupalUpdateException('Could not perform update: ' . $error);
+  }
 }


### PR DESCRIPTION
This module was using the wrong case for the "`obi`" CV. While the DB is upper case, the CV should be lower case.

This PR corrects this, and adds an update hook to re-add the `p-value` term in the correct lower case `obi` CV.